### PR TITLE
Revert "Circle CI disable javadoc qa"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ workflows:
             parameters:
               qa_step_profile: [
                 "checkstyle",
-#                "javadoc",
+                "javadoc",
                 "pmd",
                 "spotbugs"
               ]


### PR DESCRIPTION
This reverts commit f696579fa66423e6e46160d1e672cbfd94f34c3e.